### PR TITLE
ci: Add simple continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
            uses: actions/checkout@v2
 
          - name: Use Node 12
-           uses: actions/setup-node@v1
+           uses: actions/setup-node@v2
            with:
-              node-version: 12.x
+              node-version: '14'
 
          - name: Use cached node_modules
            uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
          - 'main'
 jobs:
    build:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-20.04
       if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
       steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
          - '.storybook/**'
          - '.husky/**'
       branches:
-         - 'master'
+         - 'main'
 jobs:
    build:
       runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+on:
+   push:
+      paths-ignore:
+         - 'README.md'
+         - '**.mdx'
+         - '.storybook/**'
+         - '.husky/**'
+      branches:
+         - 'master'
+jobs:
+   build:
+      runs-on: ubuntu-latest
+      if: "!contains(github.event.head_commit.message, '[skip ci]')"
+
+      steps:
+         - name: Checkout
+           uses: actions/checkout@v2
+
+         - name: Use Node 12
+           uses: actions/setup-node@v1
+           with:
+              node-version: 12.x
+
+         - name: Use cached node_modules
+           uses: actions/cache@v2
+           with:
+              path: node_modules
+              key: nodeModules-${{ hashFiles('**/package-lock.json') }}
+              restore-keys: |
+                 nodeModules-
+
+         - name: Install dependencies
+           run: npm install
+
+         - name: Lint
+           run: npm run lint
+
+         - name: Build
+           run: npm run build
+
+         - name: 'Automated Version Bump'
+           uses: 'phips28/gh-action-bump-version@master'
+           with:
+              tag-prefix: ''
+           env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,7 +10,7 @@ jobs:
          # Setup .npmrc file to publish to npm
          - uses: actions/setup-node@v2
            with:
-              node-version: '12.x'
+              node-version: '14'
               registry-url: 'https://registry.npmjs.org'
          - run: npm install
          - run: npm publish

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,18 @@
+name: Publish on NPM
+on:
+   release:
+      types: [created]
+jobs:
+   build:
+      runs-on: ubuntu-latest
+      steps:
+         - uses: actions/checkout@v2
+         # Setup .npmrc file to publish to npm
+         - uses: actions/setup-node@v2
+           with:
+              node-version: '12.x'
+              registry-url: 'https://registry.npmjs.org'
+         - run: npm install
+         - run: npm publish
+           env:
+              NODE_AUTH_TOKEN: ${{ secrets.npm_token }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,7 +4,7 @@ on:
       types: [created]
 jobs:
    build:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-20.04
       steps:
          - uses: actions/checkout@v2
          # Setup .npmrc file to publish to npm

--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@ A set of reusable React components built on top of [Chakra](https://chakra-ui.co
 
 ## Getting Started
 
-Visit [LINK TO STORYBOOK](#getting-started)
-
-## Documentation
-
-Visit [LINK TO STORYBOOK](#)
+Visit [storybook](https://ifixit-components.netlify.app/)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,99 @@
 # iFixit React Components
 
 A set of reusable React components built on top of [Chakra](https://chakra-ui.com).
+
+## Getting Started
+
+Visit [LINK TO STORYBOOK](#getting-started)
+
+## Documentation
+
+Visit [LINK TO STORYBOOK](#)
+
+## Contributing
+
+### Development setup
+
+```sh
+# Install dependencies
+npm install
+
+# Start storybook
+npm run storybook
+```
+
+### Commit message format
+
+This repo adheres to the [Conventional Commits Specification](https://www.conventionalcommits.org/) for commit messages.
+
+The commits are structured as follows:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+For example, a simple commit for adding a feature looks like this:
+
+```
+feat(Pagination): Add pagination components
+```
+
+#### Type
+
+-  **feat**: A new feature
+-  **fix**: A bug fix
+-  **refactor**: A code change that neither fixes a bug nor adds a feature
+-  **docs**: Documentation only changes
+-  **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+-  **perf**: A code change that improves performance
+-  **test**: Adding missing or correcting existing tests
+-  **chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
+-  **build**: Changes that affect the build system or external dependencies
+-  **ci**: Change to our CI configuration file and scripts
+
+#### Scope
+
+The scope could be anything specifying place of the commit change. For example Icon, Tab, SearchInput, etc...
+
+Remember that scope is entirely optional. Only include a scope if the commit message doesn't stand on it's own outside the context of a pull request.
+
+#### Description
+
+The description contains succinct explanation of the change:
+
+Use the imperative, present tense: "Change" not "Changed" nor "Changes".
+
+Use sentence case: "Some message" not "some message" nor "Some Message".
+
+Do not include a dot (.) at the end.
+
+| Commit message                                                       | Release type     |
+| -------------------------------------------------------------------- | ---------------- |
+| `fix(Pencil): Stop graphite breaking when too much pressure applied` | Patch Release    |
+| `feat(Pencil): Add 'graphiteWidth' option`                           | Feature Release  |
+| `BREAKING CHANGE: The graphiteWidth option has been removed`         | Breaking Release |
+
+### Continuous Integration
+
+Package release is automated via Github Actions.
+
+#### Bump version
+
+The `ci` workflow will perform the following tasks:
+
+-  Lint and build the package to see if it compiles
+-  Based on the commit messages, increment the version from the latest release.
+   -  If the string `BREAKING CHANGE`, `major` or the Attention pattern `refactor!: drop support for Node 6` is found anywhere in any of the commit messages or descriptions the major version will be incremented.
+   -  If a commit message begins with the string `feat` or includes `minor` then the minor version will be increased. This works for most common commit metadata for feature additions: `feat: new API` and `feature: new API`.
+   -  If a commit message contains the word "pre-alpha" or "pre-beta" or "pre-rc" then the pre-release version will be increased (for example specifying pre-alpha: 1.6.0-alpha.1 -> 1.6.0-alpha.2 or, specifying pre-beta: 1.6.0-alpha.1 -> 1.6.0-beta.0)
+   -  All other changes will increment the patch version.
+-  Push the bumped npm version in package.json back into the repo.
+-  Push a tag for the new version back into the repo.
+
+#### Publish on NPM
+
+The `npm-publish` workflow will publish the package to NPM when a Github Release is created.

--- a/src/components/Pagination/index.stories.mdx
+++ b/src/components/Pagination/index.stories.mdx
@@ -46,7 +46,14 @@ A pagination component.
                   </PaginationItem>
                   {pagination.pages.map((page) => (
                      <PaginationItem key={page}>
-                        <PaginationButton aria-label={`Go to page ${page}`} page={page} />
+                        <PaginationButton
+                           aria-label={
+                              pagination.currentPage === page
+                                 ? 'current page'
+                                 : `go to page ${page}`
+                           }
+                           page={page}
+                        />
                      </PaginationItem>
                   ))}
                   <PaginationItem>
@@ -97,7 +104,11 @@ A pagination component.
                   {pagination.pages.map((page) => (
                      <PaginationItem key={page}>
                         <PaginationLink
-                           aria-label={`Go to page ${page}`}
+                           aria-label={
+                              pagination.currentPage === page
+                                 ? 'current page'
+                                 : `go to page ${page}`
+                           }
                            href={`#${page}`}
                            page={page}
                         />
@@ -150,7 +161,14 @@ A pagination component.
                   </PaginationItem>
                   {pagination.pages.map((page) => (
                      <PaginationItem key={page}>
-                        <PaginationButton aria-label={`Go to page ${page}`} page={page} />
+                        <PaginationButton
+                           aria-label={
+                              pagination.currentPage === page
+                                 ? 'current page'
+                                 : `go to page ${page}`
+                           }
+                           page={page}
+                        />
                      </PaginationItem>
                   ))}
                   <PaginationItem>
@@ -191,9 +209,9 @@ export function ControlledExample() {
    return (
       <Pagination
          aria-label="pagination"
-         numberOfPage={10}
+         numberOfPages={context.numberOfPages}
          visibleNumberOfPages={5}
-         currentPage={context.page}
+         page={context.page}
          onChange={onPageChange}
       >
          {(pagination) => (
@@ -202,25 +220,39 @@ export function ControlledExample() {
                   <PaginationButton
                      aria-label="Go to first page"
                      page="first"
+                     icon={HiChevronDoubleLeft}
+                  />
+               </PaginationItem>
+               <PaginationItem>
+                  <PaginationButton
+                     aria-label="Go to previous page"
+                     page="previous"
                      icon={HiChevronLeft}
                   />
                </PaginationItem>
-               <PaginationItem>
-                  <PaginationPreviousButton
-                     aria-label="Go to previous page"
-                     icon={HiDoubleChevronLeft}
-                  />
-               </PaginationItem>
                {pagination.pages.map((page) => (
-                  <PaginationItem>
-                     <PaginationPageButtonButton page={page} />
+                  <PaginationItem key={page}>
+                     <PaginationButton
+                        aria-label={
+                           pagination.currentPage === page ? 'current page' : `go to page ${page}`
+                        }
+                        page={page}
+                     />
                   </PaginationItem>
                ))}
                <PaginationItem>
-                  <PaginationNextButton aria-label="Go to next page" icon={HiChevronRight} />
+                  <PaginationButton
+                     aria-label="Go to next page"
+                     page="next"
+                     icon={HiChevronRight}
+                  />
                </PaginationItem>
                <PaginationItem>
-                  <PaginationLastButton aria-label="Go to last page" icon={HiDoubleChevronRight} />
+                  <PaginationButton
+                     aria-label="Go to last page"
+                     page="last"
+                     icon={HiChevronDoubleRight}
+                  />
                </PaginationItem>
             </>
          )}


### PR DESCRIPTION
This PR adds a CI configuration based on Github Actions. 

What this configuration does:

- When commits are pushed into main branch:
  - Checks linting
  - Checks that the package builds without errors
  - Automatically bumps package version based on conventional commits (more on this on the updated readme)
- When a [Github release](https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository) is created:
  - Publishes the package to NPM

What this configuration **DOESN'T** do (yet):

- Run tests. We have to figure this part out yet, to see what kind of tests will make sense to do (probably [chromatic](https://www.chromatic.com)).

> This PR includes also small fixes and improvements to the pagination story

### 🚨 Things that needs to be done before merging 🚨 

- [x] Add a GitHub secret named `npm_token` with an npm access token. I can provide the one that Kyle sent me to whoever will do this, so he doesn't need to create a new one
