### PR TITLE
build: Fix modern bundle bug on node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
          - name: Checkout
            uses: actions/checkout@v2
 
-         - name: Use Node 12
+         - name: Use Node 14
            uses: actions/setup-node@v2
            with:
               node-version: '14'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,7 @@ on:
    release:
       types: [created]
 jobs:
-   build:
+   publish:
       runs-on: ubuntu-20.04
       steps:
          - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -5,18 +5,18 @@
       "type": "git",
       "url": "git@github.com:iFixit/react-components.git"
    },
-   "source": "src/index.tsx",
+   "source": "./src/index.tsx",
    "license": "UNLICENSED",
-   "main": "dist/react-components.js",
-   "typings": "dist/index.d.ts",
-   "exports": "dist/react-components.modern.js",
-   "module": "dist/react-components.module.js",
-   "unpkg": "dist/react-components.umd.js",
+   "main": "./dist/react-components.js",
+   "typings": "./dist/index.d.ts",
+   "exports": "./dist/react-components.modern.mjs",
+   "module": "./dist/react-components.module.js",
+   "unpkg": "./dist/react-components.umd.js",
    "files": [
       "dist"
    ],
    "scripts": {
-      "build": "microbundle --jsx React.createElement",
+      "build": "microbundle --jsx React.createElement && microbundle --jsx React.createElement -i src/index.tsx -o dist/react-components.modern.mjs --no-pkg-main -f modern",
       "dev": "microbundle watch",
       "storybook": "start-storybook -p 6006 -h localhost",
       "build-storybook": "build-storybook",


### PR DESCRIPTION
This PR fixes an issue that breaks ECMAScript modules when using node `v12.22.1` or above. This fix is actually a temporary patch, because for the most part the bug is due to a bug in Microbundle (see https://github.com/developit/microbundle/issues/795 and https://github.com/developit/microbundle/issues/825).

## QA

To QA this we can test the package on `react-commerce` repo. Follow these steps:

1. First we build the `@ifixit/react-component` package
  1.2 Clone this repo
  1.3 Make sure to use node.js v14
  1.4 Install dependencies `npm install`
  1.5 Build the package `npm run build` and `npm pack`
2. Then we test it on react-commerce repo 
  2.1. Clone [react-commerce repo](https://github.com/iFixit/react-commerce/pull/4) (`project-setup` branch)
  2.2. Copy `ifixit-react-components-0.2.1.tgz` over to the React commerce root folder
  2.3. Remove `@ifixit/react-components` from `package.json`
  2.4. Install dependencies `npm install`
  2.5. Install the built package with `npm i ifixit-react-components-0.2.1.tgz`
  2.5. Build the app `npm run build`
  2.6. Start the app `npm run start`

The should build successfully and the server should start on `localhost:3000`
